### PR TITLE
5-solucion-de-problema-sobre-precios-negativos

### DIFF
--- a/Merchandising/src/main/resources/templates/admin/form-producto.html
+++ b/Merchandising/src/main/resources/templates/admin/form-producto.html
@@ -50,7 +50,7 @@
 
 					<div class="form-group">
 						<label for="precio">Precio (€)</label>
-						<input type="number" class="form-control" id="precio" th:field="*{precio}" step="0.01"
+						<input type="number" min="0" class="form-control" id="precio" th:field="*{precio}" step="0.01"
 							required />
 					</div>
 


### PR DESCRIPTION
se usó el valor min="0" para evitar que se puedan colocar numeros negativos en el apartado del precio 